### PR TITLE
Add OSX-specific macro to the list of platforms detected as UNIX

### DIFF
--- a/ExLauncher/Views/FramePanel.cpp
+++ b/ExLauncher/Views/FramePanel.cpp
@@ -49,7 +49,10 @@ void FramePanel::OnLayoutChange()
 
 		if (v->GetSize().w == SIZE_FILL_PARENT && size.w == SIZE_WRAP_CONTENT ||
 			v->GetSize().h == SIZE_FILL_PARENT && size.h == SIZE_WRAP_CONTENT)
+		{
+			delete[] childSizes;
 			throw runtime_error("cannot calculate layout size");
+		}
 
 		Box childMargin = v->GetLayoutMargin();
 		v->SetRelativePosition(Position(childMargin.left, childMargin.top));

--- a/ExLauncher/global.h
+++ b/ExLauncher/global.h
@@ -21,7 +21,7 @@ limitations under the License.
 #define WINDOWS
 #endif
 
-#if defined(__unix) || defined(__unix__)
+#if defined(__unix) || defined(__unix__) || defined(__APPLE__)
 #define UNIX
 #endif
 


### PR DESCRIPTION
Although OSX is UNIX, it doesn't define `__unix` or `__unix__`. Instead, it uses an `__APPLE__` macro.
This pull request fixes compilation on OSX platform.
